### PR TITLE
Fix deploy-instance.sh route and ingress

### DIFF
--- a/scripts/deploy-instance.sh
+++ b/scripts/deploy-instance.sh
@@ -49,9 +49,11 @@ spec:
   server:
     grpc:
       host: ${GRPC_HOST}
-      ingress: true
+      ingress:
+        enabled: true
     host: ${HOST}
-    ingress: true
+    ingress:
+      enabled: true
     insecure: true
 EOL
 else
@@ -71,7 +73,8 @@ spec:
       g, system:cluster-admins, role:admin
     scopes: '[groups]'
   server:
-    route: ${ROUTE}
+    route: 
+      enabled: ${ROUTE}
 EOL
 fi
 


### PR DESCRIPTION
In accordance with argocd-route example https://github.com/argoproj-labs/argocd-operator/blob/master/examples/argocd-route.yaml, ingress and route needs enabled attribute