### PR TITLE
Updates RBAC configuration

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [ocp4_vpc]
+        platform: [ocp44_vpc]
 #      max-parallel: 1
       fail-fast: false
 

--- a/scripts/deploy-instance.sh
+++ b/scripts/deploy-instance.sh
@@ -72,14 +72,15 @@ kind: ArgoCD
 metadata:
   name: ${NAME}
 spec:
+  version: v1.6.1
   dex:
     image: quay.io/ablock/dex
     openShiftOAuth: true
     version: openshift-connector
   rbac:
-    defaultPolicy: 'role:readonly'
+    defaultPolicy: 'role:admin'
     policy: |
-      g, system:cluster-admins, role:admin
+      g, argocd-admins, role:admin
     scopes: '[groups]'
   server:
     route: 
@@ -88,6 +89,12 @@ spec:
           termination: passthrough
           insecureEdgeTerminationPolicy: Redirect
       wildcardPolicy: None
+---
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: argocd-admins
+users: []
 EOL
 fi
 


### PR DESCRIPTION
- Adds version: v1.6.1 to argocd yaml to fix gpg error (temporary)
- Changes default rbac permissions to `admin`
- Adds `argocd-admins` group and grants argocd-admins group admin privileges in argocd